### PR TITLE
refactor: keep config static by moving dynamic parameters to trainer

### DIFF
--- a/core/base_trainer.py
+++ b/core/base_trainer.py
@@ -1,12 +1,13 @@
 import os
 import torch
 from torch.cuda import amp
+from math import ceil
 from copy import deepcopy
 from .loss import get_loss_fn
 from models import get_model
 from datasets import get_loader, get_test_loader
-from utils import (get_optimizer, get_scheduler, parallel_model, de_parallel, 
-                    get_ema_model, set_seed, set_device, get_writer, get_logger, 
+from utils import (get_optimizer, get_scheduler, parallel_model, de_parallel,
+                    get_ema_model, set_seed, set_device, get_writer, get_logger,
                     destroy_ddp_process, mkdir, save_config, log_config,)
 
 
@@ -20,14 +21,14 @@ class BaseTrainer:
         self.rank = int(os.getenv('RANK', -1))
         self.local_rank = int(os.getenv('LOCAL_RANK', -1))
         self.world_size = int(os.getenv('WORLD_SIZE', 1))
-        config.DDP = self.local_rank != -1
+        self.is_DDP = self.local_rank != -1
         self.main_rank = self.local_rank in [-1, 0]
 
         # Logger compatible with ddp training
         self.logger = get_logger(config, self.main_rank)
 
         # Select device to train the model
-        self.device = set_device(config, self.local_rank)
+        self.device, self.gpu_num, self.num_workers = set_device(config, self.is_DDP, self.local_rank)
 
         # Automatic mixed precision training scaler
         self.scaler = amp.GradScaler(enabled=config.amp_training)
@@ -43,13 +44,30 @@ class BaseTrainer:
         self.model = get_model(config).to(self.device)
 
         if config.task == 'predict':
-            self.test_loader = get_test_loader(config)
+            self.test_loader, self.test_num = get_test_loader(config, self.is_DDP, self.num_workers)
         else:
             # Tensorboard monitor
             self.writer = get_writer(config, self.main_rank)
 
+            # Set batch size
+            self.train_bs, self.val_bs = config.train_bs, config.val_bs
+            if not self.is_DDP:
+                self.train_bs *= self.gpu_num
+
             # Get train and validate loader
-            self.train_loader, self.val_loader = get_loader(config, self.local_rank)
+            self.train_loader, self.train_num = get_loader(config, 'train', self.is_DDP, self.train_bs,
+                                                            self.local_rank, self.gpu_num, self.num_workers)
+            self.val_loader, self.val_num = get_loader(config, 'val', self.is_DDP, self.val_bs,
+                                                            self.local_rank, self.gpu_num, self.num_workers)
+
+            # Calculate number of iteration per epoch
+            if self.is_DDP:
+                self.iters_per_epoch = ceil(self.train_num/self.train_bs/self.gpu_num)
+            else:
+                self.iters_per_epoch = ceil(self.train_num/self.train_bs)
+
+            # Calculate total number of training iterations
+            self.total_itrs = int(config.total_epoch * self.iters_per_epoch)
 
             # Define variables to monitor training process
             self.best_score = 0.
@@ -61,17 +79,17 @@ class BaseTrainer:
                 self.loss_fn = get_loss_fn(config, self.device)
 
                 # Define optimizer
-                self.optimizer = get_optimizer(config, self.model)
+                self.optimizer, self.max_lr = get_optimizer(config, self.model, self.gpu_num)
 
                 # Define scheduler to control how learning rate changes
-                self.scheduler = get_scheduler(config, self.optimizer)
+                self.scheduler = get_scheduler(config, self.optimizer, self.max_lr, self.total_itrs)
 
         # Load specific checkpoints if needed
         self.load_ckpt(config)
 
         # Use exponential moving average of checkpoint update if needed
         if config.task != 'predict':
-            self.ema_model = get_ema_model(config, self.model, self.device)
+            self.ema_model = get_ema_model(config, self.model, self.total_itrs, self.device)
 
     def run(self, config):
         # Parallel the model using DP or DDP
@@ -96,10 +114,10 @@ class BaseTrainer:
                     # Save best model
                     self.best_score = val_score
                     if config.save_ckpt:
-                        self.save_ckpt(config, save_best=True) 
+                        self.save_ckpt(config, save_best=True)
 
             if self.main_rank and config.save_ckpt:
-                # Save last model    
+                # Save last model
                 self.save_ckpt(config)
 
         # Close tensorboard after training
@@ -108,14 +126,14 @@ class BaseTrainer:
             self.writer.close()
 
         # Wait for main rank to save the checkpoint
-        if config.DDP:
+        if self.is_DDP:
             torch.distributed.barrier()
 
         # Validate for the best model
         if config.save_ckpt:
             best_score = self.val_best(config)
 
-        destroy_ddp_process(config)
+        destroy_ddp_process(config, self.is_DDP)
 
         if config.save_ckpt:
             return best_score
@@ -123,16 +141,16 @@ class BaseTrainer:
             return self.best_score
 
     def parallel_model(self, config):
-        self.model = parallel_model(config, self.model, self.local_rank, self.device)
+        self.model = parallel_model(config, self.is_DDP, self.model, self.local_rank, self.device)
 
     def train_one_epoch(self, config):
-        '''You may implement whatever training process you like here, 
-            e.g. knowledge distillation, self-supervised learning or 
+        '''You may implement whatever training process you like here,
+            e.g. knowledge distillation, self-supervised learning or
             semi-supervised learning.'''
         raise NotImplementedError()
 
     def validate(self, config):
-        raise NotImplementedError()   
+        raise NotImplementedError()
 
     def predict(self, config):
         raise NotImplementedError()
@@ -151,7 +169,7 @@ class BaseTrainer:
                     self.cur_epoch = checkpoint['cur_epoch'] + 1
                     self.optimizer.load_state_dict(checkpoint['optimizer'])
                     self.scheduler.load_state_dict(checkpoint['scheduler'])
-                    self.train_itrs = self.cur_epoch * config.iters_per_epoch
+                    self.train_itrs = self.cur_epoch * self.iters_per_epoch
                     if self.main_rank:
                         self.logger.info(f"Resume training from {config.load_ckpt_path}")
 

--- a/core/loss.py
+++ b/core/loss.py
@@ -59,11 +59,11 @@ def get_loss_fn(config, device):
         weights = torch.Tensor(config.class_weights).to(device)
 
     if config.loss_type == 'ce':
-        criterion = nn.CrossEntropyLoss(ignore_index=config.ignore_index, 
+        criterion = nn.CrossEntropyLoss(ignore_index=config.ignore_index,
                                         reduction=config.reduction, weight=weights)
 
     elif config.loss_type == 'ohem':
-        criterion = OhemCELoss(thresh=config.ohem_thrs, ignore_index=config.ignore_index)  
+        criterion = OhemCELoss(thresh=config.ohem_thrs, ignore_index=config.ignore_index)
 
     else:
         raise NotImplementedError(f"Unsupport loss type: {config.loss_type}")
@@ -71,18 +71,18 @@ def get_loss_fn(config, device):
     return criterion
 
 
-def get_detail_loss_fn(config):
-    detail_loss_fn = DetailLoss(dice_loss_coef=config.dice_loss_coef, bce_loss_coef=config.bce_loss_coef)
+def get_detail_loss_fn(dice_loss_coef, bce_loss_coef):
+    detail_loss_fn = DetailLoss(dice_loss_coef=dice_loss_coef, bce_loss_coef=bce_loss_coef)
 
     return detail_loss_fn
 
 
-def kd_loss_fn(config, outputs, outputsT):
-    if config.kd_loss_type == 'kl_div':
-        lossT = F.kl_div(F.log_softmax(outputs/config.kd_temperature, dim=1),
-                    F.softmax(outputsT.detach()/config.kd_temperature, dim=1)) * config.kd_temperature ** 2
+def kd_loss_fn(loss_type, T, outputs, outputsT):
+    if loss_type == 'kl_div':
+        lossT = F.kl_div(F.log_softmax(outputs/T, dim=1),
+                    F.softmax(outputsT.detach()/T, dim=1)) * T ** 2
 
-    elif config.kd_loss_type == 'mse':
+    elif loss_type == 'mse':
         lossT = F.mse_loss(outputs, outputsT.detach())
 
     return lossT

--- a/core/seg_trainer.py
+++ b/core/seg_trainer.py
@@ -9,7 +9,7 @@ import torch.nn.functional as F
 from .base_trainer import BaseTrainer
 from .loss import kd_loss_fn
 from models import get_teacher_model
-from utils import (get_seg_metrics, sampler_set_epoch, get_colormap)
+from utils import (get_seg_metrics, get_colormap)
 
 
 class SegTrainer(BaseTrainer):
@@ -28,12 +28,13 @@ class SegTrainer(BaseTrainer):
                     from models import LaplacianConv
 
                     self.laplacian_conv = LaplacianConv(self.device)
-                    self.detail_loss_fn = get_detail_loss_fn(config)
+                    self.detail_loss_fn = get_detail_loss_fn(config.dice_loss_coef, config.bce_loss_coef)
 
     def train_one_epoch(self, config):
         self.model.train()
 
-        sampler_set_epoch(config, self.train_loader, self.cur_epoch) 
+        if self.is_DDP:
+            self.train_loader.sampler.set_epoch(self.cur_epoch)
 
         pbar = tqdm(self.train_loader) if self.main_rank else self.train_loader
 
@@ -42,7 +43,7 @@ class SegTrainer(BaseTrainer):
             self.train_itrs += 1
 
             images = images.to(self.device, dtype=torch.float32)
-            masks = masks.to(self.device, dtype=torch.long)    
+            masks = masks.to(self.device, dtype=torch.long)
 
             self.optimizer.zero_grad()
 
@@ -99,7 +100,7 @@ class SegTrainer(BaseTrainer):
                     with torch.no_grad():
                         teacher_preds = self.teacher_model(images)   # Teacher predictions
 
-                    loss_kd = kd_loss_fn(config, preds, teacher_preds.detach())
+                    loss_kd = kd_loss_fn(config.kd_loss_type, config.kd_temperature, preds, teacher_preds.detach())
                     loss += config.kd_loss_coefficient * loss_kd
 
                 if config.use_tb and self.main_rank:
@@ -115,7 +116,7 @@ class SegTrainer(BaseTrainer):
             self.ema_model.update(self.model, self.train_itrs)
 
             if self.main_rank:
-                pbar.set_description(('%s'*2) % 
+                pbar.set_description(('%s'*2) %
                                 (f'Epoch:{self.cur_epoch}/{config.total_epoch}{" "*4}|',
                                 f'Loss:{loss.detach():4.4g}{" "*4}|',)
                                 )
@@ -140,10 +141,10 @@ class SegTrainer(BaseTrainer):
 
         if self.main_rank:
             if val_best:
-                self.logger.info(f'\n\nTrain {config.total_epoch} epochs finished.' + 
+                self.logger.info(f'\n\nTrain {config.total_epoch} epochs finished.' +
                                  f'\n\nBest mIoU is: {score:.4f}\n')
             else:
-                self.logger.info(f' Epoch{self.cur_epoch} mIoU: {score:.4f}    | ' + 
+                self.logger.info(f' Epoch{self.cur_epoch} mIoU: {score:.4f}    | ' +
                                  f'best mIoU so far: {self.best_score:.4f}\n')
 
             if config.use_tb and self.cur_epoch < config.total_epoch:
@@ -155,7 +156,7 @@ class SegTrainer(BaseTrainer):
 
     @torch.no_grad()
     def predict(self, config):
-        if config.DDP:
+        if self.is_DDP:
             raise ValueError('Predict mode currently does not support DDP.')
 
         self.logger.info('\nStart predicting...\n')

--- a/datasets/__init__.py
+++ b/datasets/__init__.py
@@ -4,61 +4,48 @@ from .cityscapes import Cityscapes
 from .dataset_registry import dataset_hub
 
 
-def get_dataset(config):
-    if config.dataset in dataset_hub.keys():
-        train_dataset = dataset_hub[config.dataset](config=config, mode='train')
-        val_dataset = dataset_hub[config.dataset](config=config, mode='val')
-    else:
+def get_dataset(config, mode):
+    if config.dataset not in dataset_hub.keys():
         raise NotImplementedError('Unsupported dataset!')
 
-    return train_dataset, val_dataset
+    return dataset_hub[config.dataset](config=config, mode=mode)
 
 
-def get_loader(config, rank, pin_memory=True):
-    train_dataset, val_dataset = get_dataset(config)
+def get_loader(config, mode, is_DDP, batch_size, rank, gpu_num, num_workers, pin_memory=True):
+    dataset = get_dataset(config, mode)
+
+    is_train = mode == 'train'
 
     # Make sure train number is divisible by train batch size
-    config.train_num = int(len(train_dataset) // config.train_bs * config.train_bs)
-    config.val_num = len(val_dataset)
+    num_samples = int(len(dataset) // batch_size * batch_size) if is_train else len(dataset)
 
-    if config.DDP:
+    if is_DDP:
         from torch.utils.data.distributed import DistributedSampler
-        train_sampler = DistributedSampler(train_dataset, num_replicas=config.gpu_num, 
-                                            rank=rank, shuffle=True)
-        val_sampler = DistributedSampler(val_dataset, num_replicas=config.gpu_num,
-                                            rank=rank, shuffle=False)
+        sampler = DistributedSampler(dataset, num_replicas=gpu_num, rank=rank, shuffle=is_train)
+    else:   # DP
+        sampler = None
 
-        train_loader = DataLoader(train_dataset, batch_size=config.train_bs, shuffle=False, 
-                                    num_workers=config.num_workers, pin_memory=pin_memory, 
-                                    sampler=train_sampler, drop_last=True)
+    loader = DataLoader(dataset, batch_size=batch_size, shuffle=(is_train and not is_DDP),
+                        sampler=sampler, num_workers=num_workers, pin_memory=pin_memory,
+                        drop_last=is_train)
 
-        val_loader = DataLoader(val_dataset, batch_size=config.val_bs, shuffle=False,
-                                    num_workers=config.num_workers, pin_memory=pin_memory,
-                                    sampler=val_sampler)
-    else:
-        train_loader = DataLoader(train_dataset, batch_size=config.train_bs, 
-                                    shuffle=True, num_workers=config.num_workers, drop_last=True)
-
-        val_loader = DataLoader(val_dataset, batch_size=config.val_bs, 
-                                    shuffle=False, num_workers=config.num_workers)
-
-    return train_loader, val_loader
+    return loader, num_samples
 
 
-def get_test_loader(config): 
+def get_test_loader(config, is_DDP, num_workers):
     from .test_dataset import TestDataset
     dataset = TestDataset(config)
 
-    config.test_num = len(dataset)
+    test_num = len(dataset)
 
-    if config.DDP:
+    if is_DDP:
         raise NotImplementedError()
 
     else:
-        test_loader = DataLoader(dataset, batch_size=config.test_bs, 
-                                    shuffle=False, num_workers=config.num_workers)
+        test_loader = DataLoader(dataset, batch_size=config.test_bs,
+                                    shuffle=False, num_workers=num_workers)
 
-    return test_loader
+    return test_loader, test_num
 
 
 def list_available_datasets():

--- a/utils/model_ema.py
+++ b/utils/model_ema.py
@@ -9,12 +9,12 @@ from copy import deepcopy
 from .parallel import de_parallel
 
 
-def get_ema_model(config, model, device):
-    return ModelEmaV2(config, model, device=device)
+def get_ema_model(config, model, total_itrs, device):
+    return ModelEmaV2(config, model, total_itrs, device=device)
 
 
 class ModelEmaV2(nn.Module):
-    def __init__(self, config, model, device=None):
+    def __init__(self, config, model, total_itrs, device=None):
         super().__init__()
         # make a copy of the model for accumulating moving average of weights
         self.ema = deepcopy(de_parallel(model))
@@ -22,8 +22,8 @@ class ModelEmaV2(nn.Module):
         self.device = device  # perform ema on different device from model if set
         if self.device is not None:
             self.ema.to(device=device)
-        self.use_ema = config.use_ema    
-        self.total_itrs = config.total_itrs    
+        self.use_ema = config.use_ema
+        self.total_itrs = total_itrs
 
     @torch.no_grad()
     def _update(self, model, update_fn):

--- a/utils/optimizer.py
+++ b/utils/optimizer.py
@@ -1,21 +1,21 @@
 from torch.optim import SGD, Adam, AdamW
 
 
-def get_optimizer(config, model):    
+def get_optimizer(config, model, gpu_num):
     optimizer_hub = {'sgd':SGD, 'adam':Adam, 'adamw':AdamW}
     params = model.parameters()
 
     if config.optimizer_type == 'sgd':
-        config.lr = config.base_lr * config.gpu_num
-        optimizer = optimizer_hub[config.optimizer_type](params=params, lr=config.lr, 
-                                                    momentum=config.momentum, 
+        max_lr = config.base_lr * gpu_num
+        optimizer = optimizer_hub[config.optimizer_type](params=params, lr=max_lr,
+                                                    momentum=config.momentum,
                                                     weight_decay=config.weight_decay)
 
     elif config.optimizer_type in ['adam', 'adamw']:
-        config.lr = 0.1 * config.base_lr * config.gpu_num
-        optimizer = optimizer_hub[config.optimizer_type](params=params, lr=config.lr)
+        max_lr = 0.1 * config.base_lr * gpu_num
+        optimizer = optimizer_hub[config.optimizer_type](params=params, lr=max_lr)
 
     else:
         raise NotImplementedError(f'Unsupported optimizer type: {config.optimizer_type}')
 
-    return optimizer
+    return optimizer, max_lr

--- a/utils/parallel.py
+++ b/utils/parallel.py
@@ -14,29 +14,28 @@ def de_parallel(model):
     return model.module if is_parallel(model) else model
 
 
-def set_device(config, rank):
-    if config.DDP:
+def set_device(config, is_DDP, rank):
+    if is_DDP:
         torch.cuda.set_device(rank)
         if not dist.is_initialized():
             dist.init_process_group(backend=dist.Backend.NCCL, init_method='env://')
         device = torch.device('cuda', rank)
-        config.gpu_num = dist.get_world_size()
+        gpu_num = dist.get_world_size()
     else:   # DP
         device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
-        config.gpu_num = torch.cuda.device_count()
-        config.train_bs *= config.gpu_num
+        gpu_num = torch.cuda.device_count()
 
     # Setup num_workers
-    config.num_workers = config.gpu_num * config.base_workers
+    num_workers = gpu_num * config.base_workers
 
-    return device
+    return device, gpu_num, num_workers
 
 
-def parallel_model(config, model, rank, device):
-    if config.DDP:
+def parallel_model(config, is_DDP, model, rank, device):
+    if is_DDP:
         if config.synBN:
             model = nn.SyncBatchNorm.convert_sync_batchnorm(model)
-        model = DDP(model.to(rank), device_ids=[rank], output_device=rank)    
+        model = DDP(model.to(rank), device_ids=[rank], output_device=rank)
     else:
         model = nn.DataParallel(model)
         model.to(device)
@@ -44,11 +43,6 @@ def parallel_model(config, model, rank, device):
     return model
 
 
-def destroy_ddp_process(config):
-    if config.DDP and config.destroy_ddp_process:
+def destroy_ddp_process(config, is_DDP):
+    if is_DDP and config.destroy_ddp_process:
         dist.destroy_process_group()
-
-
-def sampler_set_epoch(config, loader, cur_epochs):
-    if config.DDP:
-        loader.sampler.set_epoch(cur_epochs)

--- a/utils/scheduler.py
+++ b/utils/scheduler.py
@@ -1,21 +1,14 @@
 from torch.optim.lr_scheduler import OneCycleLR, StepLR
-from math import ceil
 
 
-def get_scheduler(config, optimizer):
-    if config.DDP:
-        config.iters_per_epoch = ceil(config.train_num/config.train_bs/config.gpu_num)
-    else:
-        config.iters_per_epoch = ceil(config.train_num/config.train_bs)
-    config.total_itrs = int(config.total_epoch*config.iters_per_epoch)
-
+def get_scheduler(config, optimizer, max_lr, total_itrs):
     if config.lr_policy == 'cos_warmup':
         warmup_ratio = config.warmup_epochs / config.total_epoch
-        scheduler = OneCycleLR(optimizer, max_lr=config.lr, total_steps=config.total_itrs, 
+        scheduler = OneCycleLR(optimizer, max_lr=max_lr, total_steps=total_itrs,
                                 pct_start=warmup_ratio)
 
     elif config.lr_policy == 'linear':
-        scheduler = OneCycleLR(optimizer, max_lr=config.lr, total_steps=config.total_itrs, 
+        scheduler = OneCycleLR(optimizer, max_lr=max_lr, total_steps=total_itrs,
                                 pct_start=0., anneal_strategy='linear')
 
     elif config.lr_policy == 'step':

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -44,13 +44,12 @@ def save_config(config):
 
 
 def log_config(config, logger):
-    keys = ['task', 'dataset', 'num_class', 'model', 'encoder', 'decoder', 'loss_type', 
-            'optimizer_type', 'lr_policy', 'total_epoch', 'train_bs', 'val_bs',  
-            'train_num', 'val_num', 'gpu_num', 'num_workers', 'amp_training', 
-            'DDP', 'kd_training', 'synBN', 'use_ema', 'use_aux']
+    keys = ['task', 'dataset', 'num_class', 'model', 'encoder', 'decoder', 'loss_type',
+            'optimizer_type', 'lr_policy', 'total_epoch', 'train_bs', 'val_bs',
+            'amp_training', 'kd_training', 'synBN', 'use_ema', 'use_aux']
 
     config_dict = vars(config)
-    infos = f"\n\n\n{'#'*25} Config Informations {'#'*25}\n" 
+    infos = f"\n\n\n{'#'*25} Config Informations {'#'*25}\n"
     infos += '\n'.join('%s: %s' % (k, config_dict[k]) for k in keys)
     infos += f"\n{'#'*71}\n\n"
     logger.info(infos)


### PR DESCRIPTION
Refactored the codebase to ensure the configuration object remains immutable and static during runtime. Shifting on-the-fly calculated variables to the trainer prevents the config from "growing" during training.